### PR TITLE
Pin scripts to specific commit hash instead of master

### DIFF
--- a/build142
+++ b/build142
@@ -22,5 +22,5 @@ EOF
 ./configure --disable-docs --disable-manage-submodules --enable-local-rust \
     --local-rust-root="$base"/rust-s20120829/x86_64-unknown-linux-gnu/stage2 \
     --llvm-root="$base"/llvm-3.1svn-4/Release+Asserts
-make -j8 rustc-stage1
+make -j8 rustc-stage2
 printf '\a'

--- a/build177
+++ b/build177
@@ -4,7 +4,7 @@ git -C rust worktree add "$base"/rust-s20130917 \
     cbd1eefbd350797b783df119fed7956d7e1c74ad
 git -C rust-s20130917 config --worktree core.abbrev 7
 git -C libuv archive v0.11.11 | tar -xf - -C rust-s20130917/src/libuv
-git -C gyp archive master | tar -xf - -C rust-s20130917/src/gyp
+git -C gyp archive f407f09c94e00d2d570e8e42114e3f6848b2deb2 | tar -xf - -C rust-s20130917/src/gyp
 cd rust-s20130917
 patch -p1 <<EOF
 --- a/configure

--- a/build178
+++ b/build178
@@ -4,7 +4,7 @@ git -C rust worktree add "$base"/rust-s20130923 \
     348d8446739f9633897a3d728d265ee6ac59c8fb
 git -C rust-s20130923 config --worktree core.abbrev 7
 git -C libuv archive v0.11.11 | tar -xf - -C rust-s20130923/src/libuv
-git -C gyp archive master | tar -xf - -C rust-s20130923/src/gyp
+git -C gyp archive f407f09c94e00d2d570e8e42114e3f6848b2deb2 | tar -xf - -C rust-s20130923/src/gyp
 cd rust-s20130923
 patch -p1 <<EOF
 --- a/configure

--- a/build179
+++ b/build179
@@ -4,7 +4,7 @@ git -C rust worktree add "$base"/rust-s20130926 \
     1434b4bfcafe90cffa6627e3be18a9e5b6501ad1
 git -C rust-s20130926 config --worktree core.abbrev 7
 git -C libuv archive v0.11.11 | tar -xf - -C rust-s20130926/src/libuv
-git -C gyp archive master | tar -xf - -C rust-s20130926/src/gyp
+git -C gyp archive f407f09c94e00d2d570e8e42114e3f6848b2deb2 | tar -xf - -C rust-s20130926/src/gyp
 cd rust-s20130926
 patch -p1 <<EOF
 --- a/configure

--- a/build180
+++ b/build180
@@ -4,7 +4,7 @@ git -C rust worktree add "$base"/rust-s20131001 \
     320af9b15723b10c31daa2e9fa8266486f4ba009
 git -C rust-s20131001 config --worktree core.abbrev 7
 git -C libuv archive v0.11.11 | tar -xf - -C rust-s20131001/src/libuv
-git -C gyp archive master | tar -xf - -C rust-s20131001/src/gyp
+git -C gyp archive f407f09c94e00d2d570e8e42114e3f6848b2deb2 | tar -xf - -C rust-s20131001/src/gyp
 cd rust-s20131001
 patch -p1 <<EOF
 --- a/configure

--- a/build181
+++ b/build181
@@ -4,7 +4,7 @@ git -C rust worktree add "$base"/rust-s20131007 \
     c9196290af3934481bd413e11057725f248fd104
 git -C rust-s20131007 config --worktree core.abbrev 7
 git -C libuv archive v0.11.11 | tar -xf - -C rust-s20131007/src/libuv
-git -C gyp archive master | tar -xf - -C rust-s20131007/src/gyp
+git -C gyp archive f407f09c94e00d2d570e8e42114e3f6848b2deb2 | tar -xf - -C rust-s20131007/src/gyp
 cd rust-s20131007
 patch -p1 <<EOF
 --- a/configure

--- a/build182
+++ b/build182
@@ -4,7 +4,7 @@ git -C rust worktree add "$base"/rust-s20131010 \
     8015f9c27ec342dbf0b28c9c0c4769d8b3bcfc9f
 git -C rust-s20131010 config --worktree core.abbrev 7
 git -C libuv archive v0.11.11 | tar -xf - -C rust-s20131010/src/libuv
-git -C gyp archive master | tar -xf - -C rust-s20131010/src/gyp
+git -C gyp archive f407f09c94e00d2d570e8e42114e3f6848b2deb2 | tar -xf - -C rust-s20131010/src/gyp
 cd rust-s20131010
 patch -p1 <<EOF
 --- a/configure

--- a/build183
+++ b/build183
@@ -4,7 +4,7 @@ git -C rust worktree add "$base"/rust-s20131016 \
     6c08cc2db4f98e9f07ae7d50338396c4123c2f0a
 git -C rust-s20131016 config --worktree core.abbrev 7
 git -C libuv archive v0.11.11 | tar -xf - -C rust-s20131016/src/libuv
-git -C gyp archive master | tar -xf - -C rust-s20131016/src/gyp
+git -C gyp archive f407f09c94e00d2d570e8e42114e3f6848b2deb2 | tar -xf - -C rust-s20131016/src/gyp
 cd rust-s20131016
 patch -p1 <<EOF
 --- a/configure

--- a/build184
+++ b/build184
@@ -4,7 +4,7 @@ git -C rust worktree add "$base"/rust-s20131021 \
     6e6981c3eb92ab87342ae9ccb3ead879fb7cbdb0
 git -C rust-s20131021 config --worktree core.abbrev 7
 git -C libuv archive v0.11.11 | tar -xf - -C rust-s20131021/src/libuv
-git -C gyp archive master | tar -xf - -C rust-s20131021/src/gyp
+git -C gyp archive f407f09c94e00d2d570e8e42114e3f6848b2deb2 | tar -xf - -C rust-s20131021/src/gyp
 cd rust-s20131021
 patch -p1 <<EOF
 --- a/configure

--- a/build185
+++ b/build185
@@ -4,7 +4,7 @@ git -C rust worktree add "$base"/rust-s20131022 \
     ae0905ab67a2dd3def61e266bba9f8f223586af6
 git -C rust-s20131022 config --worktree core.abbrev 7
 git -C libuv archive v0.11.11 | tar -xf - -C rust-s20131022/src/libuv
-git -C gyp archive master | tar -xf - -C rust-s20131022/src/gyp
+git -C gyp archive f407f09c94e00d2d570e8e42114e3f6848b2deb2 | tar -xf - -C rust-s20131022/src/gyp
 cd rust-s20131022
 patch -p1 <<EOF
 --- a/configure

--- a/build186
+++ b/build186
@@ -4,7 +4,7 @@ git -C rust worktree add "$base"/rust-s20131028 \
     2ab4a6fab046769ddad48de557f64b0a97f86ce3
 git -C rust-s20131028 config --worktree core.abbrev 7
 git -C libuv archive v0.11.11 | tar -xf - -C rust-s20131028/src/libuv
-git -C gyp archive master | tar -xf - -C rust-s20131028/src/gyp
+git -C gyp archive f407f09c94e00d2d570e8e42114e3f6848b2deb2 | tar -xf - -C rust-s20131028/src/gyp
 cd rust-s20131028
 patch -p1 <<EOF
 --- a/configure

--- a/build187
+++ b/build187
@@ -4,7 +4,7 @@ git -C rust worktree add "$base"/rust-s20131029 \
     fed48cc861fd858762c1e9b498675bfa4dee2d38
 git -C rust-s20131029 config --worktree core.abbrev 7
 git -C libuv archive v0.11.11 | tar -xf - -C rust-s20131029/src/libuv
-git -C gyp archive master | tar -xf - -C rust-s20131029/src/gyp
+git -C gyp archive f407f09c94e00d2d570e8e42114e3f6848b2deb2 | tar -xf - -C rust-s20131029/src/gyp
 cd rust-s20131029
 patch -p1 <<EOF
 --- a/configure

--- a/build188
+++ b/build188
@@ -4,7 +4,7 @@ git -C rust worktree add "$base"/rust-s20131101 \
     8ea2123055dcbc1caa0bb07bc492516027b832b4
 git -C rust-s20131101 config --worktree core.abbrev 7
 git -C libuv archive v0.11.11 | tar -xf - -C rust-s20131101/src/libuv
-git -C gyp archive master | tar -xf - -C rust-s20131101/src/gyp
+git -C gyp archive f407f09c94e00d2d570e8e42114e3f6848b2deb2 | tar -xf - -C rust-s20131101/src/gyp
 cd rust-s20131101
 patch -p1 <<EOF
 --- a/configure

--- a/build189
+++ b/build189
@@ -4,7 +4,7 @@ git -C rust worktree add "$base"/rust-s20131106 \
     fdc830df31df205c8edc5e11268a011d44c8bc09
 git -C rust-s20131106 config --worktree core.abbrev 7
 git -C libuv archive v0.11.11 | tar -xf - -C rust-s20131106/src/libuv
-git -C gyp archive master | tar -xf - -C rust-s20131106/src/gyp
+git -C gyp archive f407f09c94e00d2d570e8e42114e3f6848b2deb2 | tar -xf - -C rust-s20131106/src/gyp
 cd rust-s20131106
 patch -p1 <<EOF
 --- a/configure

--- a/build190
+++ b/build190
@@ -4,7 +4,7 @@ git -C rust worktree add "$base"/rust-s20131110 \
     b5e602ac563422e13a18be9f79100f96359d582a
 git -C rust-s20131110 config --worktree core.abbrev 7
 git -C libuv archive v0.11.19 | tar -xf - -C rust-s20131110/src/libuv
-git -C gyp archive master | tar -xf - -C rust-s20131110/src/gyp
+git -C gyp archive f407f09c94e00d2d570e8e42114e3f6848b2deb2 | tar -xf - -C rust-s20131110/src/gyp
 cd rust-s20131110
 patch -p1 <<EOF
 --- a/configure

--- a/build191
+++ b/build191
@@ -4,7 +4,7 @@ git -C rust worktree add "$base"/rust-s20131128 \
     859c3baf64c167730f4214a736f72a5e2e86d7d9
 git -C rust-s20131128 config --worktree core.abbrev 7
 git -C libuv archive v0.11.19 | tar -xf - -C rust-s20131128/src/libuv
-git -C gyp archive master | tar -xf - -C rust-s20131128/src/gyp
+git -C gyp archive f407f09c94e00d2d570e8e42114e3f6848b2deb2 | tar -xf - -C rust-s20131128/src/gyp
 cd rust-s20131128
 patch -p1 <<EOF
 --- a/configure

--- a/build192
+++ b/build192
@@ -4,7 +4,7 @@ git -C rust worktree add "$base"/rust-s20131130 \
     4252a24ae1236207a99c1d313d4b1b1eda3ebb58
 git -C rust-s20131130 config --worktree core.abbrev 7
 git -C libuv archive v0.11.19 | tar -xf - -C rust-s20131130/src/libuv
-git -C gyp archive master | tar -xf - -C rust-s20131130/src/gyp
+git -C gyp archive f407f09c94e00d2d570e8e42114e3f6848b2deb2 | tar -xf - -C rust-s20131130/src/gyp
 cd rust-s20131130
 patch -p1 <<EOF
 --- a/configure

--- a/build193
+++ b/build193
@@ -4,7 +4,7 @@ git -C rust worktree add "$base"/rust-s20131207 \
     49b751dda19af57a2545a67879dd217e601b84c6
 git -C rust-s20131207 config --worktree core.abbrev 7
 git -C libuv archive v0.11.19 | tar -xf - -C rust-s20131207/src/libuv
-git -C gyp archive master | tar -xf - -C rust-s20131207/src/gyp
+git -C gyp archive f407f09c94e00d2d570e8e42114e3f6848b2deb2 | tar -xf - -C rust-s20131207/src/gyp
 cd rust-s20131207
 patch -p1 <<EOF
 --- a/configure

--- a/build194
+++ b/build194
@@ -4,7 +4,7 @@ git -C rust worktree add "$base"/rust-s20131210 \
     b8b16ae0996074861693f0f76d5d937fafe6a37e
 git -C rust-s20131210 config --worktree core.abbrev 7
 git -C libuv archive v0.11.19 | tar -xf - -C rust-s20131210/src/libuv
-git -C gyp archive master | tar -xf - -C rust-s20131210/src/gyp
+git -C gyp archive f407f09c94e00d2d570e8e42114e3f6848b2deb2 | tar -xf - -C rust-s20131210/src/gyp
 cd rust-s20131210
 patch -p1 <<EOF
 --- a/configure

--- a/build195
+++ b/build195
@@ -4,7 +4,7 @@ git -C rust worktree add "$base"/rust-s20131217 \
     d5798b3902c4af50bf0f24e1c4bbf5e4a4dcc6ca
 git -C rust-s20131217 config --worktree core.abbrev 7
 git -C libuv archive v0.11.19 | tar -xf - -C rust-s20131217/src/libuv
-git -C gyp archive master | tar -xf - -C rust-s20131217/src/gyp
+git -C gyp archive f407f09c94e00d2d570e8e42114e3f6848b2deb2 | tar -xf - -C rust-s20131217/src/gyp
 cd rust-s20131217
 patch -p1 <<EOF
 --- a/configure

--- a/build196
+++ b/build196
@@ -4,7 +4,7 @@ git -C rust worktree add "$base"/rust-s20131225 \
     cab6af55ff64148de1cda707f7d4c85f062f1ff4
 git -C rust-s20131225 config --worktree core.abbrev 7
 git -C libuv archive v0.11.19 | tar -xf - -C rust-s20131225/src/libuv
-git -C gyp archive master | tar -xf - -C rust-s20131225/src/gyp
+git -C gyp archive f407f09c94e00d2d570e8e42114e3f6848b2deb2 | tar -xf - -C rust-s20131225/src/gyp
 cd rust-s20131225
 patch -p1 <<EOF
 --- a/configure

--- a/build197
+++ b/build197
@@ -4,7 +4,7 @@ git -C rust worktree add "$base"/rust-s20131227 \
     a5fa1d95bc422b8f7da00c5098db232916a0d1b7
 git -C rust-s20131227 config --worktree core.abbrev 7
 git -C libuv archive v0.11.19 | tar -xf - -C rust-s20131227/src/libuv
-git -C gyp archive master | tar -xf - -C rust-s20131227/src/gyp
+git -C gyp archive f407f09c94e00d2d570e8e42114e3f6848b2deb2 | tar -xf - -C rust-s20131227/src/gyp
 cd rust-s20131227
 patch -p1 <<EOF
 --- a/configure

--- a/build198
+++ b/build198
@@ -4,7 +4,7 @@ git -C rust worktree add "$base"/rust-s20140105 \
     a6d3e57dca68fde4effdda3e4ae2887aa535fcd6
 git -C rust-s20140105 config --worktree core.abbrev 7
 git -C libuv archive v0.11.19 | tar -xf - -C rust-s20140105/src/libuv
-git -C gyp archive master | tar -xf - -C rust-s20140105/src/gyp
+git -C gyp archive f407f09c94e00d2d570e8e42114e3f6848b2deb2 | tar -xf - -C rust-s20140105/src/gyp
 cd rust-s20140105
 patch -p1 <<EOF
 --- a/mk/platform.mk

--- a/build199
+++ b/build199
@@ -4,7 +4,7 @@ git -C rust worktree add "$base"/rust-s20140108 \
     f3a8baafbecdb6e41f001c8f218d4796a9ca8d40
 git -C rust-s20140108 config --worktree core.abbrev 7
 git -C libuv archive v0.11.19 | tar -xf - -C rust-s20140108/src/libuv
-git -C gyp archive master | tar -xf - -C rust-s20140108/src/gyp
+git -C gyp archive f407f09c94e00d2d570e8e42114e3f6848b2deb2 | tar -xf - -C rust-s20140108/src/gyp
 cd rust-s20140108
 patch -p1 <<EOF
 --- a/mk/platform.mk

--- a/build200
+++ b/build200
@@ -5,7 +5,7 @@ git -C rust worktree add "$base"/rust-s20140114 \
 cd rust-s20140114
 git config --worktree core.abbrev 7
 git -C "$base"/libuv archive v0.11.19 | tar -xf - -C src/libuv
-git -C "$base"/gyp archive master | tar -xf - -C src/gyp
+git -C "$base"/gyp archive f407f09c94e00d2d570e8e42114e3f6848b2deb2 | tar -xf - -C src/gyp
 patch -p1 <<EOF
 --- a/mk/platform.mk
 +++ b/mk/platform.mk

--- a/build201
+++ b/build201
@@ -5,7 +5,7 @@ git -C rust worktree add "$base"/rust-s20140120 \
 cd rust-s20140120
 git config --worktree core.abbrev 7
 git -C "$base"/libuv archive v0.11.19 | tar -xf - -C src/libuv
-git -C "$base"/gyp archive master | tar -xf - -C src/gyp
+git -C "$base"/gyp archive f407f09c94e00d2d570e8e42114e3f6848b2deb2 | tar -xf - -C src/gyp
 patch -p1 <<EOF
 --- a/mk/platform.mk
 +++ b/mk/platform.mk


### PR DESCRIPTION
for https://chromium.googlesource.com/external/gyp.git, the master is no longer working, pin commit hash to `f407f09c94e00d2d570e8e42114e3f6848b2deb2`